### PR TITLE
Price parameter forgotten from example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ paypal.pay('20130001', 123.23, 'iPad', 'EUR', function(err, url) {
 // or
 // paypal.detail(partialjs.controller, callback);
 
-paypal.detail('EC-788441863R616634K', '9TM892TKTDWCE', function(err, data, invoiceNumber) {
+paypal.detail('EC-788441863R616634K', '9TM892TKTDWCE', function(err, data, invoiceNumber, price) {
 	
 	if (err) {
 		console.log(err);


### PR DESCRIPTION
Stumbled upon this when passing my own custom parameters, which one returned price instead of my parameter.

Quick look at source revealed that the example indeed missed one parameter.
