### PR TITLE
feat(pay): add `opts` param to Paypal.pay, which allows overriding params

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,7 @@ Paypal.prototype.detail = function(token, payer, callback) {
 	return {Paypal}
 */
 Paypal.prototype.pay = function(invoiceNumber, amout, description, currency, opts, callback) {
+  if(typeof(opts) == 'function'){callback = opts}
 
 	var self = this;
 	var params = self.params();


### PR DESCRIPTION
This commit adds the `opts` param to `Paypal.prototype.pay`. Ideally, we can use it for all params that need to be set, and to allow overriding any `self.params()` on the `paypal` instance. In this particular commit, I'm simply overriding `params.RETURNURL` and `params.CANCELURL`. Reason being I have a different url for each user, so these urls need to be set at the pay level - not the global level. but if you find this PR agreeable, I'll augment all the params as such, so it looks like:

``` diff
diff --git a/index.js b/index.js
index b31ef08..2696be4 100644
--- a/index.js
+++ b/index.js
@@ -91,7 +91,7 @@ Paypal.prototype.detail = function(token, payer, callback) {
    @callback {Function} :: callback(err, url);
    return {Paypal}
 */
-Paypal.prototype.pay = function(invoiceNumber, amout, description, currency, callback) {
+Paypal.prototype.pay = function(opts, callback) {

    var self = this;
    var params = self.params();

```
